### PR TITLE
購入された商品に"SOLD OUT"をつける

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,6 @@ class ItemsController < ApplicationController
 
   def item_params
     params.require(:item).permit(:name, :description, :price, :image, :category,
-      :status, :delivery_fee, :prefecture, :delivery_day).merge(user_id: current_user.id)
+      :status, :delivery_fee, :prefecture, :delivery_day, :buyed).merge(user_id: current_user.id)
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -127,25 +127,51 @@
     <ul class='item-lists'>
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-       <%= @items.each do |item| %>
-        <li class='list'>
-          <%= link_to item_path(item.id) do %>
-          <div class='item-img-content'>
-            <%= image_tag item.image.variant(resize:'207x207'), class: "item-img" if item.image.attached? %>
 
-            <%# 商品が売れていればsold outを表示しましょう %>
-            <div class='sold-out'>
-              <span>Sold Out!!</span>
+        <% @items.each do |item| %>
+          <li class='list'>
+            <%= link_to item_path(item) do %>
+            <div class='item-img-content'>
+              <%= image_tag item.image.variant(resize:'207x207'), class: "item-img" if item.image.attached? %>
+
+              <%# 商品が売れていればsold outを表示しましょう %>
+              <% if item.buyed %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <% end %>
+              <%# //商品が売れていればsold outを表示しましょう %>
+
             </div>
-            <%# //商品が売れていればsold outを表示しましょう %>
+            <div class='item-info'>
+              <h3 class='item-name'>
+                <%= item.name %>
+              </h3>
+              <div class='item-price'>
+                <span><%= item.price %>円<br>(税込み)</span>
+                <div class='star-btn'>
+                  <%= image_tag "star.png", class:"star-icon" %>
+                  <span class='star-count'>0</span>
+                </div>
+              </div>
+            </div>
+            <% end %>
+          </li>
+        <% end %>
+      
+      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
 
-          </div>
+      <%# 商品がない場合のダミー %>
+      <%# 商品がある場合は表示されないようにしましょう %>
+        <li class='list'>
+          <%= link_to '#' do %>
+          <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
           <div class='item-info'>
             <h3 class='item-name'>
-              <%= item.name %>
+              商品を出品してね！
             </h3>
             <div class='item-price'>
-              <span><%= item.price %>円<br>(税込み)</span>
+              <span>99999999円<br>(税込み)</span>
               <div class='star-btn'>
                 <%= image_tag "star.png", class:"star-icon" %>
                 <span class='star-count'>0</span>
@@ -154,28 +180,6 @@
           </div>
           <% end %>
         </li>
-      <% end %>
-      <%# //商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
-
-      <%# 商品がない場合のダミー %>
-      <%# 商品がある場合は表示されないようにしましょう %>
-      <li class='list'>
-        <%= link_to '#' do %>
-        <%= image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/10/a004.png", class: "item-img" %>
-        <div class='item-info'>
-          <h3 class='item-name'>
-            商品を出品してね！
-          </h3>
-          <div class='item-price'>
-            <span>99999999円<br>(税込み)</span>
-            <div class='star-btn'>
-              <%= image_tag "star.png", class:"star-icon" %>
-              <span class='star-count'>0</span>
-            </div>
-          </div>
-        </div>
-        <% end %>
-      </li>
       <%# //商品がある場合は表示されないようにしましょう %>
       <%# /商品がない場合のダミー %>
     </ul>

--- a/db/migrate/20200902052139_create_items.rb
+++ b/db/migrate/20200902052139_create_items.rb
@@ -10,6 +10,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :delivery_fee, null: false
       t.integer :prefecture,   null: false
       t.integer :delivery_day, null: false
+      t.boolean :buyed      
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2020_09_02_052139) do
     t.integer "delivery_fee", null: false
     t.integer "prefecture", null: false
     t.integer "delivery_day", null: false
+    t.boolean "buyed"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"


### PR DESCRIPTION
#What
トップページに出品した商品の一覧表示
画像、商品名、価格の表示
売却済みの商品にSOLD OUTの文字を表示
ログインしていなくても一覧を見られる

#Why
どのような商品が出品されているかわかる
商品の情報を一部見ることができる
購入できる商品かどうかわかる
新規登録していなくても商品の閲覧ができる

非ログイン状態での商品一覧表示画面
https://gyazo.com/4fb7b48c6715a31938148d965b812825